### PR TITLE
added PWM ability

### DIFF
--- a/AMSpi.py
+++ b/AMSpi.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------
 # Project:  AMSpi class
 # Author:   Jan Lipovský, 2016
+#           Daniel Neumann, 2017
 # E-mail:   janlipovsky@gmail.com
 # Licence:  MIT
 # Description: Python class for controlling
@@ -32,10 +33,12 @@ class AMSpi:
     _DIR_SER = None
 
     # DC Motors states and settings
-    # pin - pin on which is DC Motor connected
-    # direction - list of numbers that set direction of motor (clockwise, counterclockwise, no spin)
-    # is_running - True if motor is running
+    # pin               - PIN on which is DC Motor connected
+    # direction         - List of numbers that set direction of motor (clockwise, counterclockwise, no spin)
+    # is_running        - True if motor is running
     # running_direction - Direction of the motor
+    # pwm_frequency     - Frequency of pulse-width modulation (pwm)
+    # pwm               - Un-/set pwm object
     _MOTORS = {
         DC_Motor_1: {"pin": None, "direction": [4, 8, 4 | 8], "is_running": False,
                         "running_direction": None, "pwm_frequency": 50, "pwm": None},
@@ -215,6 +218,7 @@ class AMSpi:
 
         :param int dc_motor: number of dc motor
         :param bool clockwise: True for clockwise False for counterclockwise
+        :param int speed: pwm duty cycle (range 0-100)
         :return: False in case of an ERROR, True if everything is OK
         :rtype bool
         """
@@ -233,7 +237,7 @@ class AMSpi:
         elif speed >= 0 and speed <= 100:
             self._MOTORS[dc_motor]["pwm"] = GPIO.PWM(self._MOTORS[dc_motor]["pin"],
                                                      self._MOTORS[dc_motor]["pwm_frequency"])
-            self._MOTORS[dc_motor]["pwm"].start(speed) # argument is duty cycle
+            self._MOTORS[dc_motor]["pwm"].start(speed)
         else:
             print("WARNING: Speed argument must be in range 0-100! " + str(speed) + " given.")
             return False
@@ -249,6 +253,7 @@ class AMSpi:
 
         :param list[int] dc_motors: list of dc motor numbers
         :param bool clockwise: True for clockwise, False for counterclockwise
+        :param int speed: pwm duty cycle (range 0-100)
         :return: False in case of an ERROR, True if everything is OK
         :rtype bool
         """

--- a/AMSpi.py
+++ b/AMSpi.py
@@ -37,10 +37,14 @@ class AMSpi:
     # is_running - True if motor is running
     # running_direction - Direction of the motor
     _MOTORS = {
-        DC_Motor_1: {"pin": None, "direction": [4, 8, 4 | 8], "is_running": False, "running_direction": None},
-        DC_Motor_2: {"pin": None, "direction": [2, 16, 2 | 16], "is_running": False, "running_direction": None},
-        DC_Motor_3: {"pin": None, "direction": [32, 128, 32 | 128], "is_running": False, "running_direction": None},
-        DC_Motor_4: {"pin": None, "direction": [1, 64, 1 | 64], "is_running": False, "running_direction": None}
+        DC_Motor_1: {"pin": None, "direction": [4, 8, 4 | 8], "is_running": False,
+                        "running_direction": None, "pwm_frequency": 50, "pwm": None},
+        DC_Motor_2: {"pin": None, "direction": [2, 16, 2 | 16], "is_running": False,
+                        "running_direction": None, "pwm_frequency": 50, "pwm": None},
+        DC_Motor_3: {"pin": None, "direction": [32, 128, 32 | 128], "is_running": False,
+                        "running_direction": None, "pwm_frequency": 50, "pwm": None},
+        DC_Motor_4: {"pin": None, "direction": [1, 64, 1 | 64], "is_running": False,
+                        "running_direction": None, "pwm_frequency": 50, "pwm": None}
     }
 
     # indexes of motor direction list
@@ -135,7 +139,7 @@ class AMSpi:
         """
         Set PINs used on Raspberry Pi to connect with 74HC595 module on
         Arduino Motor Shield
-        
+
         :param int PWM0A: PWM0A PIN number
         :param int PWM0B: PWM0B PIN number
         :param int PWM2A: PWM2A PIN number
@@ -179,7 +183,33 @@ class AMSpi:
 
         return all_motors_direction, direction_value
 
-    def run_dc_motor(self, dc_motor, clockwise=True):
+    def set_pwm_frequency(self, frequencies):
+        """
+        Sets the pulse-width modulation (pwm) frequencies for each motor.
+
+        :param list of int: Values for pwm frequencies. Should be high enough to run smoothly, but
+                            too high values can cause RPi.GPIO to crash.
+        """
+        if size(frequencies) is not size(self._MOTORS):
+            print("ERROR: Size of frequency list must be equal to size of motors ("+size(self._MOTORS)+")!")
+        else:
+            for i in range(0,size(frequencies)):
+                self._MOTORS[i]["pwm_frequency"] = frequencies[i]
+
+    def get_pwm_frequency(self):
+        """
+        Returns the current list of pulse-width modulation (pwm) frequencies for each motor.
+
+        :return: Current pwm frequency for each motor as list.
+        :rtype list of int
+        """
+        frequencies = []
+        for m in self._MOTORS:
+            frequencies += m["pwm_frequency"]
+
+        return frequencies
+
+    def run_dc_motor(self, dc_motor, clockwise=True, speed=None):
         """
         Run motor with given direction
 
@@ -197,14 +227,23 @@ class AMSpi:
         # set motors direction
         self._shift_write(all_motors_direction)
 
-        # turn the motor on
-        GPIO.output(self._MOTORS[dc_motor]["pin"], GPIO.HIGH)
+        # turn the motor on (if speed argument is not given then full speed, otherwise set pwm according to speed)
+        if speed is None:
+            GPIO.output(self._MOTORS[dc_motor]["pin"], GPIO.HIGH)
+        elif speed >= 0 and speed <= 100:
+            self._MOTORS[dc_motor]["pwm"] = GPIO.PWM(self._MOTORS[dc_motor]["pin"],
+                                                     self._MOTORS[dc_motor]["pwm_frequency"])
+            self._MOTORS[dc_motor]["pwm"].start(speed) # argument is duty cycle
+        else:
+            print("WARNING: Speed argument must be in range 0-100! " + str(speed) + " given.")
+            return False
+
         self._MOTORS[dc_motor]["is_running"] = True
         self._MOTORS[dc_motor]["running_direction"] = direction_value
 
         return True
 
-    def run_dc_motors(self, dc_motors, clockwise=True):
+    def run_dc_motors(self, dc_motors, clockwise=True, speed=None):
         """
         Run motors with given direction
 
@@ -214,7 +253,7 @@ class AMSpi:
         :rtype bool
         """
         for dc_motor in dc_motors:
-            self.run_dc_motor(dc_motor, clockwise)
+            self.run_dc_motor(dc_motor, clockwise, speed)
 
     def stop_dc_motor(self, dc_motor):
         """
@@ -232,9 +271,15 @@ class AMSpi:
         # set motors direction
         self._shift_write(all_motors_direction)
 
-        GPIO.output(self._MOTORS[dc_motor]["pin"], GPIO.LOW)
+        if self._MOTORS[dc_motor]["pwm"] is None:
+            GPIO.output(self._MOTORS[dc_motor]["pin"], GPIO.LOW)
+        else:
+            self._MOTORS[dc_motor]["pwm"].stop()
+            self._MOTORS[dc_motor]["pwm"] = None
+
         self._MOTORS[dc_motor]["is_running"] = False
         self._MOTORS[dc_motor]["running_direction"] = None
+
         return True
 
     def stop_dc_motors(self, dc_motors):
@@ -248,4 +293,6 @@ class AMSpi:
         for dc_motor in dc_motors:
             if not self.stop_dc_motor(dc_motor):
                 return False
+
         return True
+

--- a/example.py
+++ b/example.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------
 # Project:  AMSpi class
 # Author:   Jan Lipovský, 2016
+#           Daniel Neumann, 2017
 # E-mail:   janlipovsky@gmail.com
 # Licence:  MIT
 # Description: Example of usage ASMpi class
@@ -29,6 +30,14 @@ if __name__ == '__main__':
 
         print("GO: counterclockwise")
         amspi.run_dc_motors([amspi.DC_Motor_1, amspi.DC_Motor_2, amspi.DC_Motor_3, amspi.DC_Motor_4], clockwise=False)
+        time.sleep(2)
+
+        print("Stop")
+        amspi.stop_dc_motors([amspi.DC_Motor_1, amspi.DC_Motor_2, amspi.DC_Motor_3, amspi.DC_Motor_4])
+        time.sleep(1)
+
+        print("GO: clockwise with 50% of maximum speed")
+        amspi.run_dc_motors([amspi.DC_Motor_1, amspi.DC_Motor_2, amspi.DC_Motor_3, amspi.DC_Motor_4], speed=50)
         time.sleep(2)
 
         print("Stop")


### PR DESCRIPTION
uses RPi.GPIO.PWM:
    - PWM frequency is globally set in _MOTORS dictionary (50 Hz by default), but can be accessed/changed with getter/setter function
    - PWM duty cycle is used for speed control (0-100), additional speed argument for run_dc_motors function